### PR TITLE
remove redundant 'if'

### DIFF
--- a/lib/todo_trek_web/live/home_live.ex
+++ b/lib/todo_trek_web/live/home_live.ex
@@ -198,7 +198,7 @@ defmodule TodoTrekWeb.HomeLive do
       [_ | _] = logs ->
         socket
         |> assign(end_of_timeline?: false)
-        |> assign(page: if(logs == [], do: cur_page, else: new_page))
+        |> assign(page: new_page)
         |> stream(:activity_logs, logs, at: at, limit: limit)
     end
   end


### PR DESCRIPTION
My IDE complains that this `if` is redundant because `logs == []` will always be false (because we're within the `[_ | _] = logs` branch of the `case` statement.

Is this a typo or am I missing something?