### PR TITLE
Update elixir min version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule TodoTrek.MixProject do
     [
       app: :todo_trek,
       version: "0.1.0",
-      elixir: "~> 1.14",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
phoenix_live_reload 1.5 uses Code.loaded?, which was introduced in Elixir 1.15.0. Bump the min version to 1.15.0 to accommodate this change.

This could also be fixed by setting the phoenix_live_reload version def to something like `"~> 1.2.0 and < 1.5.0"`